### PR TITLE
change API for Document usage

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -34,7 +34,7 @@ var ErrCursorClosed = errors.New("usage of closed Cursor")
 // Cursor iterates over key-values in a database.
 type Cursor struct {
 	ptr    unsafe.Pointer
-	doc    *Document
+	doc    Document
 	closed bool
 }
 
@@ -55,13 +55,13 @@ func (cur *Cursor) Close() error {
 
 // Next fetches the next row for the cursor
 // Returns next row if it exists else it will return nil
-func (cur *Cursor) Next() *Document {
+func (cur *Cursor) Next() Document {
 	if cur.closed {
-		return nil
+		return Document{}
 	}
 	ptr := spGet(cur.ptr, cur.doc.ptr)
 	if ptr == nil {
-		return nil
+		return Document{}
 	}
 	cur.doc.ptr = ptr
 	return cur.doc

--- a/data_store.go
+++ b/data_store.go
@@ -16,20 +16,20 @@ type dataStore struct {
 }
 
 // Get retrieves the row for the set of keys.
-func (d *dataStore) Get(doc *Document) (*Document, error) {
+func (d *dataStore) Get(doc Document) (Document, error) {
 	ptr := spGet(d.ptr, doc.ptr)
 	if ptr == nil {
 		err := d.env.Error()
 		if err == nil {
-			return nil, ErrNotFound
+			return Document{}, ErrNotFound
 		}
-		return nil, fmt.Errorf("failed Get document: err=%v", err)
+		return Document{}, fmt.Errorf("failed Get document: err=%v", err)
 	}
 	return newDocument(ptr, 0), nil
 }
 
 // Set sets the row of the set of keys.
-func (d *dataStore) Set(doc *Document) error {
+func (d *dataStore) Set(doc Document) error {
 	if !spSet(d.ptr, doc.ptr) {
 		return fmt.Errorf("failed Set document: err=%v", d.env.Error())
 	}
@@ -37,7 +37,7 @@ func (d *dataStore) Set(doc *Document) error {
 }
 
 // Upsert sets the row of the set of keys.
-func (d *dataStore) Upsert(doc *Document) error {
+func (d *dataStore) Upsert(doc Document) error {
 	if !spUpsert(d.ptr, doc.ptr) {
 		return fmt.Errorf("failed Upsert document: err=%v", d.env.Error())
 	}
@@ -45,7 +45,7 @@ func (d *dataStore) Upsert(doc *Document) error {
 }
 
 // Delete deletes row with specified set of keys.
-func (d *dataStore) Delete(doc *Document) error {
+func (d *dataStore) Delete(doc Document) error {
 	if !spDelete(d.ptr, doc.ptr) {
 		return fmt.Errorf("failed Delete document: err=%v", d.env.Error())
 	}

--- a/database.go
+++ b/database.go
@@ -86,17 +86,17 @@ type Database struct {
 }
 
 // Document creates a Document for a single or multi-statement transactions
-func (db *Database) Document() *Document {
+func (db *Database) Document() Document {
 	ptr := spDocument(db.ptr)
 	if ptr == nil {
-		return nil
+		return Document{}
 	}
 	return newDocument(ptr, db.fieldsCount)
 }
 
 // Cursor returns a Cursor for iterating over rows in the database
-func (db *Database) Cursor(doc *Document) (*Cursor, error) {
-	if nil == doc {
+func (db *Database) Cursor(doc Document) (*Cursor, error) {
+	if doc.IsEmpty() {
 		return nil, errors.New("failed to create cursor: nil Document")
 	}
 	cPtr := spCursor(db.env.ptr)

--- a/database_test.go
+++ b/database_test.go
@@ -549,8 +549,6 @@ func TestDatabaseDeleteNotExistingKey(t *testing.T) {
 	require.Nil(t, db.Delete(doc))
 }
 
-// ATTN - This benchmark don't show real performance
-// It is just a long running tests
 func BenchmarkDatabaseSet(b *testing.B) {
 	const (
 		keyPath           = "key"
@@ -592,19 +590,18 @@ func BenchmarkDatabaseSet(b *testing.B) {
 			value: fmt.Sprintf(ValueTemplate, i),
 		})
 	}
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		index := i % RecordsCountBench
 		doc := db.Document()
-		require.True(b, doc.Set(keyPath, pairs[index].key))
-		require.True(b, doc.Set(valuePath, pairs[index].value))
-		require.Nil(b, db.Set(doc))
+		doc.Set(keyPath, pairs[index].key)
+		doc.Set(valuePath, pairs[index].value)
+		db.Set(doc)
 		doc.Free()
 	}
 }
 
-// ATTN - This benchmark don't show real performance
-// It is just a long running tests
 func BenchmarkDatabaseGet(b *testing.B) {
 	const (
 		keyPath           = "key"
@@ -655,16 +652,13 @@ func BenchmarkDatabaseGet(b *testing.B) {
 		doc.Free()
 	}
 
-	var size int
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		index := i % RecordsCountBench
 		doc := db.Document()
 		require.True(b, doc.Set(keyPath, pairs[index].key))
-		d, err := db.Get(doc)
+		d, _ := db.Get(doc)
 		doc.Free()
-		require.Nil(b, err)
-		require.Equal(b, pairs[index].value, d.GetString(valuePath, &size))
 		d.Destroy()
 	}
 }

--- a/database_test.go
+++ b/database_test.go
@@ -36,7 +36,7 @@ func TestDatabaseDocument(t *testing.T) {
 	defer env.Close()
 
 	doc := db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 }
 
@@ -64,7 +64,7 @@ func TestDatabaseSetInClosedEnvironment(t *testing.T) {
 	require.NotNil(t, db)
 
 	doc := db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 	defer doc.Free()
 
@@ -101,7 +101,7 @@ func TestDatabaseSet(t *testing.T) {
 	defer env.Close()
 
 	doc := db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 	defer doc.Free()
 
@@ -131,7 +131,7 @@ func TestDatabaseGetFromClosedEnvironment(t *testing.T) {
 	require.NotNil(t, db)
 
 	doc := db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 	defer doc.Free()
 
@@ -139,7 +139,7 @@ func TestDatabaseGetFromClosedEnvironment(t *testing.T) {
 
 	d, err := db.Get(doc)
 	require.NotNil(t, err)
-	require.Nil(t, d)
+	require.True(t, d.IsEmpty())
 }
 
 func TestDatabaseGet(t *testing.T) {
@@ -169,7 +169,7 @@ func TestDatabaseGet(t *testing.T) {
 	defer env.Close()
 
 	doc := db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 
 	require.True(t, doc.SetString(keyPath, expectedKey))
@@ -179,7 +179,7 @@ func TestDatabaseGet(t *testing.T) {
 	doc.Free()
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 	defer doc.Free()
 
@@ -187,7 +187,7 @@ func TestDatabaseGet(t *testing.T) {
 
 	d, err := db.Get(doc)
 	require.Nil(t, err)
-	require.NotNil(t, d)
+	require.False(t, d.IsEmpty())
 	d.Destroy()
 }
 
@@ -211,7 +211,7 @@ func TestDatabaseDeleteFromClosedEnvironment(t *testing.T) {
 	require.NotNil(t, db)
 
 	doc := db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 	defer doc.Free()
 
@@ -247,7 +247,7 @@ func TestDatabaseDelete(t *testing.T) {
 	defer env.Close()
 
 	doc := db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 
 	require.True(t, doc.SetString(keyPath, expectedKey))
@@ -257,7 +257,7 @@ func TestDatabaseDelete(t *testing.T) {
 	doc.Free()
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 
 	require.True(t, doc.SetString(keyPath, expectedKey))
@@ -266,7 +266,7 @@ func TestDatabaseDelete(t *testing.T) {
 	doc.Free()
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 	defer doc.Free()
 
@@ -275,7 +275,7 @@ func TestDatabaseDelete(t *testing.T) {
 	d, err := db.Get(doc)
 	require.NotNil(t, err)
 	require.Equal(t, ErrNotFound, err)
-	require.Nil(t, d)
+	require.True(t, d.IsEmpty())
 }
 
 func TestDatabaseWithCustomSchema(t *testing.T) {
@@ -309,7 +309,7 @@ func TestDatabaseWithCustomSchema(t *testing.T) {
 	const expectedValue int64 = 73
 
 	doc := db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.True(t, doc.Set(keyPath, expectedKey))
 	require.True(t, doc.Set(valuePath, expectedValue))
 
@@ -318,21 +318,20 @@ func TestDatabaseWithCustomSchema(t *testing.T) {
 	require.Nil(t, err)
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.True(t, doc.Set(keyPath, expectedKey))
 
 	d, err := db.Get(doc)
 	doc.Free()
 	require.Nil(t, err)
-	require.NotNil(t, d)
-
-	defer d.Destroy()
+	require.False(t, d.IsEmpty())
 
 	require.Equal(t, expectedKey, d.GetInt(keyPath))
 	require.Equal(t, expectedValue, d.GetInt(valuePath))
+	d.Destroy()
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 
 	require.True(t, doc.Set(keyPath, expectedKey))
@@ -341,7 +340,7 @@ func TestDatabaseWithCustomSchema(t *testing.T) {
 	doc.Free()
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 	defer doc.Free()
 
@@ -350,7 +349,7 @@ func TestDatabaseWithCustomSchema(t *testing.T) {
 	d, err = db.Get(doc)
 	require.NotNil(t, err)
 	require.Equal(t, ErrNotFound, err)
-	require.Nil(t, d)
+	require.True(t, d.IsEmpty())
 }
 
 func TestDatabaseWithMultipleKeys(t *testing.T) {
@@ -394,7 +393,7 @@ func TestDatabaseWithMultipleKeys(t *testing.T) {
 	)
 
 	doc := db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.True(t, doc.Set(key1Path, expectedKey1))
 	require.True(t, doc.Set(key2Path, expectedKey2))
 	require.True(t, doc.Set(key3Path, expectedKey3))
@@ -405,7 +404,7 @@ func TestDatabaseWithMultipleKeys(t *testing.T) {
 	require.Nil(t, err)
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.True(t, doc.Set(key1Path, expectedKey1))
 	require.True(t, doc.Set(key2Path, expectedKey2))
 	require.True(t, doc.Set(key3Path, expectedKey3))
@@ -413,17 +412,16 @@ func TestDatabaseWithMultipleKeys(t *testing.T) {
 	d, err := db.Get(doc)
 	doc.Free()
 	require.Nil(t, err)
-	require.NotNil(t, d)
-
-	defer d.Destroy()
+	require.False(t, d.IsEmpty())
 
 	require.Equal(t, expectedKey1, d.GetInt(key1Path))
 	require.Equal(t, expectedKey2, d.GetInt(key2Path))
 	require.Equal(t, expectedKey3, d.GetInt(key3Path))
 	require.Equal(t, expectedValue, d.GetInt(valuePath))
+	d.Destroy()
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 
 	require.True(t, doc.Set(key1Path, expectedKey1))
@@ -434,7 +432,7 @@ func TestDatabaseWithMultipleKeys(t *testing.T) {
 	doc.Free()
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.Nil(t, env.Error())
 	defer doc.Free()
 
@@ -445,7 +443,7 @@ func TestDatabaseWithMultipleKeys(t *testing.T) {
 	d, err = db.Get(doc)
 	require.NotNil(t, err)
 	require.Equal(t, ErrNotFound, err)
-	require.Nil(t, d)
+	require.True(t, d.IsEmpty())
 }
 
 func TestDatabaseUseSomeDocumentsAtTheSameTime(t *testing.T) {
@@ -495,12 +493,12 @@ func TestDatabaseUseSomeDocumentsAtTheSameTime(t *testing.T) {
 	doc2.Free()
 
 	doc := db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 
 	doc.Set(keyPath, expectedKey1)
 	d, err := db.Get(doc)
 	doc.Free()
-	require.NotNil(t, d)
+	require.False(t, d.IsEmpty())
 	require.Nil(t, err)
 	size := 0
 	require.Equal(t, expectedValue1, d.GetString(valuePath, &size))
@@ -508,12 +506,12 @@ func TestDatabaseUseSomeDocumentsAtTheSameTime(t *testing.T) {
 	d.Destroy()
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 
 	doc.Set(keyPath, expectedKey2)
 	d, err = db.Get(doc)
 	doc.Free()
-	require.NotNil(t, d)
+	require.False(t, d.IsEmpty())
 	require.Nil(t, err)
 	size = 0
 	require.Equal(t, expectedValue2, d.GetString(valuePath, &size))

--- a/document.go
+++ b/document.go
@@ -8,11 +8,11 @@ import (
 // Document is a representation of a row in a database.
 // Destroy should be called after Document usage.
 type Document struct {
-	*varStore
+	varStore
 }
 
-func newDocument(ptr unsafe.Pointer, size int) *Document {
-	return &Document{
+func newDocument(ptr unsafe.Pointer, size int) Document {
+	return Document{
 		varStore: newVarStore(ptr, size),
 	}
 }

--- a/environment.go
+++ b/environment.go
@@ -14,7 +14,7 @@ var ErrEnvironmentClosed = errors.New("usage of closed environment")
 // Take it's name from sophia
 // Usually object with same features are called 'database'
 type Environment struct {
-	*varStore
+	varStore
 }
 
 // NewEnvironment creates a new environment for opening a database.

--- a/manual_tests/issue2/main.go
+++ b/manual_tests/issue2/main.go
@@ -79,7 +79,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	for d := cursor.Next(); d != nil; d = cursor.Next() {
+	for d := cursor.Next(); !d.IsEmpty(); d = cursor.Next() {
 		var size int
 		fmt.Println(d.GetString("key", &size), ":", d.GetInt("value"), ":", d.GetInt("value2"), ":", size)
 	}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -84,13 +84,13 @@ func TestTxGet(t *testing.T) {
 	require.Nil(t, err)
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.True(t, doc.Set(keyPath, expectedKey))
 
 	d, err := tx.Get(doc)
 	doc.Free()
 
-	require.NotNil(t, d)
+	require.False(t, d.IsEmpty())
 	require.Nil(t, err)
 
 	var size int
@@ -135,12 +135,12 @@ func TestTxDelete(t *testing.T) {
 	doc.Free()
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.True(t, doc.Set(keyPath, expectedKey))
 
 	d, err := db.Get(doc)
 	doc.Free()
-	require.NotNil(t, d)
+	require.False(t, d.IsEmpty())
 	require.Nil(t, err)
 
 	var size int
@@ -152,17 +152,17 @@ func TestTxDelete(t *testing.T) {
 	require.Nil(t, err)
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.True(t, doc.Set(keyPath, expectedKey))
 	require.Nil(t, tx.Delete(doc))
 	doc.Free()
 
 	doc = db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.True(t, doc.Set(keyPath, expectedKey))
 	d, err = tx.Get(doc)
 	doc.Free()
-	require.Nil(t, d)
+	require.True(t, d.IsEmpty())
 	require.NotNil(t, err)
 
 	require.Equal(t, TxOk, tx.Commit())
@@ -209,7 +209,7 @@ func TestTxRollback(t *testing.T) {
 	require.True(t, doc.Set(keyPath, expectedKey))
 
 	d, err := db.Get(doc)
-	require.Nil(t, d)
+	require.True(t, d.IsEmpty())
 	require.Equal(t, ErrNotFound, err)
 	doc.Free()
 }
@@ -278,7 +278,7 @@ func TestConcurrentTx(t *testing.T) {
 	d, err := db.Get(doc)
 	doc.Free()
 	require.Nil(t, err)
-	require.NotNil(t, d)
+	require.False(t, d.IsEmpty())
 	value := d.GetString(valuePath, &size)
 	require.Equal(t, expectedValue1, value)
 	d.Destroy()

--- a/upsert_test.go
+++ b/upsert_test.go
@@ -171,7 +171,7 @@ func TestDatabaseUpsertError(t *testing.T) {
 	require.Nil(t, env.Open())
 	defer env.Close()
 	doc := db.Document()
-	require.NotNil(t, doc)
+	require.False(t, doc.IsEmpty())
 	require.True(t, doc.Set("key", 1))
 	require.True(t, doc.Set("id", 1))
 	require.NotNil(t, db.Upsert(doc))

--- a/var_store.go
+++ b/var_store.go
@@ -17,11 +17,16 @@ type varStore struct {
 	pointers []unsafe.Pointer
 }
 
-func newVarStore(ptr unsafe.Pointer, size int) *varStore {
-	return &varStore{
-		ptr:      ptr,
-		pointers: make([]unsafe.Pointer, 0, size),
+func newVarStore(ptr unsafe.Pointer, size int) varStore {
+	ret := varStore{ptr: ptr}
+	if size > 0 {
+		ret.pointers = make([]unsafe.Pointer, 0, size)
 	}
+	return ret
+}
+
+func (s *varStore) IsEmpty() bool {
+	return s.ptr == nil
 }
 
 // TODO :: implement custom types


### PR DESCRIPTION
Document is just a wrapper for sophia pointer, so it is not necessary to be a pointer for Document. 
If we will use it by value everywhere it can be allocated on stack instead of heap. It helps to avoid expensive heap allocations.

```
name           old time/op    new time/op    delta
DatabaseSet-4    8.24µs ± 3%    7.99µs ± 4%     ~     (p=0.151 n=5+5)
DatabaseGet-4    5.07µs ± 2%    4.44µs ± 2%  -12.46%  (p=0.008 n=5+5)

name           old alloc/op   new alloc/op   delta
DatabaseSet-4     88.0B ± 0%     48.0B ± 0%  -45.45%  (p=0.008 n=5+5)
DatabaseGet-4      112B ± 0%       32B ± 0%  -71.43%  (p=0.008 n=5+5)

name           old allocs/op  new allocs/op  delta
DatabaseSet-4      5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.008 n=5+5)
DatabaseGet-4      6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.008 n=5+5)
```