### PR TITLE
Fix upsert test assertion

### DIFF
--- a/upsert_test.go
+++ b/upsert_test.go
@@ -279,6 +279,6 @@ func TestDatabaseUpsertArguments(t *testing.T) {
 		require.NotNil(t, result)
 
 		require.EqualValues(t, expected.key, result.GetInt(keyPath))
-		require.EqualValues(t, expected.key, result.GetInt(keyPath))
+		require.EqualValues(t, expected.value, result.GetInt(valuePath))
 	}
 }


### PR DESCRIPTION
## Summary
- fix equality assertion in upsert argument test

## Testing
- `go mod tidy` *(fails: module download forbidden)*
- `GO111MODULE=off go test ./...` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_684718df87f8832e82e974157ce71444